### PR TITLE
Invoke python using "python3"

### DIFF
--- a/plugin/boxdraw.vim
+++ b/plugin/boxdraw.vim
@@ -29,7 +29,7 @@ function! boxdraw#Draw(cmd, args)
 	let y2 = p2[1] - 1
 	let x1 = p1[2] + p1[3] - 1
 	let x2 = p2[2] + p2[3] - 1
-	let c = ['python', s:drawscript, shellescape(a:cmd), y1, x1, y2, x2] + a:args
+	let c = ['python3', s:drawscript, shellescape(a:cmd), y1, x1, y2, x2] + a:args
 	execute "%!" . join(c, " ")
 	call setpos(".", p2)
 endfunction
@@ -48,7 +48,7 @@ function! boxdraw#Select(cmd)
 	let x2 = p2[2] + p2[3] - 1
 
 	let contents = join(getline(1,'$'), "\n")
-	let c = ['python', s:drawscript, shellescape(a:cmd), y1, x1, y2, x2]
+	let c = ['python3', s:drawscript, shellescape(a:cmd), y1, x1, y2, x2]
 	let result = system(join(c, " "), contents)
 
 	let coords = split(result, ",")

--- a/python/boxdraw.py
+++ b/python/boxdraw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import textwrap
 from pprint import pprint
 


### PR DESCRIPTION
Many systems (e.g. Debian) no longer provide the "python" command as
Python 2 is end of life and the "python" command is usually associated
with Python 2.

Fixes: https://github.com/gyim/vim-boxdraw/issues/11